### PR TITLE
Track IP address when contest starts

### DIFF
--- a/cms/db/user.py
+++ b/cms/db/user.py
@@ -26,9 +26,9 @@
 """
 
 from datetime import datetime, timedelta
-from ipaddress import IPv4Network, IPv6Network
+from ipaddress import IPv4Network, IPv6Network, IPv4Address, IPv6Address
 
-from sqlalchemy.dialects.postgresql import ARRAY, CIDR
+from sqlalchemy.dialects.postgresql import ARRAY, CIDR, INET
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column, ForeignKey, CheckConstraint, \
     UniqueConstraint
@@ -168,6 +168,11 @@ class Participation(Base):
     # decided to start their time-frame.
     starting_time: datetime | None = Column(
         DateTime,
+        nullable=True)
+
+    # IP address from which the contestant started the contest.
+    starting_ip: IPv4Address | IPv6Address | None = Column(
+        INET,
         nullable=True)
 
     # A shift in the time interval during which the user is allowed to

--- a/cms/server/admin/templates/participation.html
+++ b/cms/server/admin/templates/participation.html
@@ -96,6 +96,13 @@
       </tr>
       <tr>
         <td>
+          <span class="info" title="IP address used when the contestant started the contest."></span>
+          Starting IP address
+        </td>
+        <td>{{ participation.starting_ip if participation.starting_ip is not none else "" }}</td>
+      </tr>
+      <tr>
+        <td>
           <span class="info" title="To be set (in seconds) to acknowledge that the contestant lost that amount of time at the beginning of the contest.
                                     If this is non-zero, all the events (token generation, end of contest) for this contestant will be shifted of the appropriate amount."></span>
           Delay

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -270,8 +270,21 @@ class StartHandler(ContestHandler):
     def post(self):
         participation: Participation = self.current_user
 
-        logger.info("Starting now for user %s", participation.user.username)
+        logger.info(
+            "Starting now for user %s from %s",
+            participation.user.username,
+            self.request.remote_ip,
+        )
         participation.starting_time = self.timestamp
+        try:
+            participation.starting_ip = ipaddress.ip_address(
+                self.request.remote_ip
+            )
+        except ValueError:
+            logger.warning(
+                "Invalid IP address provided by Tornado: %s",
+                self.request.remote_ip,
+            )
         self.sql_session.commit()
 
         self.redirect(self.contest_url())

--- a/cmscontrib/updaters/update_from_1.5.sql
+++ b/cmscontrib/updaters/update_from_1.5.sql
@@ -45,4 +45,7 @@ ALTER TABLE user_test_results DROP COLUMN evaluation_sandbox;
 -- https://github.com/cms-dev/cms/pull/1486
 ALTER TABLE public.tasks ADD COLUMN allowed_languages varchar[];
 
+-- Track starting IP address for participations
+ALTER TABLE public.participations ADD COLUMN starting_ip inet;
+
 COMMIT;


### PR DESCRIPTION
## Summary
- record contestant IP when starting the contest
- expose starting IP in admin participation page
- include DB migration to add `starting_ip` column

## Testing
- `pytest cmstestsuite/unit_tests/schema_diff_test.py::TestSchemaDiff::test_schema_diff -q` *(fails: ModuleNotFoundError: No module named 'bcrypt')*
- `pip install bcrypt` *(fails: Could not find a version that satisfies the requirement bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68aee00d9760833289f1b0f123fbdd97