### PR TITLE
Add export participants info button

### DIFF
--- a/cms/db/base.py
+++ b/cms/db/base.py
@@ -23,7 +23,7 @@ import ipaddress
 from datetime import datetime, timedelta
 import typing
 
-from sqlalchemy.dialects.postgresql import ARRAY, CIDR, JSONB, OID
+from sqlalchemy.dialects.postgresql import ARRAY, CIDR, INET, JSONB, OID
 from sqlalchemy.ext.declarative import as_declarative
 from sqlalchemy.orm import \
     class_mapper, object_mapper, ColumnProperty, RelationshipProperty
@@ -58,6 +58,7 @@ _TYPE_MAP = {
     CastingArray: list,
     FilenameSchemaArray: list,
     CIDR: (ipaddress.IPv4Network, ipaddress.IPv6Network),
+    INET: (ipaddress.IPv4Address, ipaddress.IPv6Address),
     JSONB: object,
 }
 

--- a/cms/db/user.py
+++ b/cms/db/user.py
@@ -26,9 +26,9 @@
 """
 
 from datetime import datetime, timedelta
-from ipaddress import IPv4Network, IPv6Network
+from ipaddress import IPv4Network, IPv6Network, IPv4Address, IPv6Address
 
-from sqlalchemy.dialects.postgresql import ARRAY, CIDR
+from sqlalchemy.dialects.postgresql import ARRAY, CIDR, INET
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column, ForeignKey, CheckConstraint, \
     UniqueConstraint
@@ -168,6 +168,11 @@ class Participation(Base):
     # decided to start their time-frame.
     starting_time: datetime | None = Column(
         DateTime,
+        nullable=True)
+
+    # IP address from which the user started their time-frame.
+    starting_ip: IPv4Address | IPv6Address | None = Column(
+        INET,
         nullable=True)
 
     # A shift in the time interval during which the user is allowed to

--- a/cms/server/admin/handlers/__init__.py
+++ b/cms/server/admin/handlers/__init__.py
@@ -55,7 +55,8 @@ from .contestuser import \
     RemoveParticipationHandler, \
     AddContestUserHandler, \
     ParticipationHandler, \
-    MessageHandler
+    MessageHandler, \
+    ExportParticipantsHandler
 from .dataset import \
     DatasetSubmissionsHandler, \
     CloneDatasetHandler, \
@@ -131,6 +132,7 @@ HANDLERS = [
     # Contest's users
 
     (r"/contest/([0-9]+)/users", ContestUsersHandler),
+    (r"/contest/([0-9]+)/users/export", ExportParticipantsHandler),
     (r"/contest/([0-9]+)/users/add", AddContestUserHandler),
     (r"/contest/([0-9]+)/user/([0-9]+)/remove", RemoveParticipationHandler),
     (r"/contest/([0-9]+)/user/([0-9]+)/edit", ParticipationHandler),

--- a/cms/server/admin/handlers/contestuser.py
+++ b/cms/server/admin/handlers/contestuser.py
@@ -30,6 +30,8 @@
 """
 
 import logging
+import csv
+import io
 
 import collections
 try:
@@ -291,3 +293,36 @@ class MessageHandler(BaseHandler):
                         user.username, self.contest.name)
 
         self.redirect(self.url("contest", contest_id, "user", user_id, "edit"))
+
+
+class ExportParticipantsHandler(BaseHandler):
+    """Exports contest participants information as CSV."""
+
+    @require_permission(BaseHandler.AUTHENTICATED)
+    def get(self, contest_id):
+        contest = self.safe_get_item(Contest, contest_id)
+        participations: list[Participation] = (
+            self.sql_session.query(Participation)
+            .filter(Participation.contest == contest)
+            .all()
+        )
+
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(
+            ["username", "first_name", "last_name", "starting_time", "starting_ip"]
+        )
+        for p in participations:
+            user = p.user
+            starting_time = p.starting_time.isoformat() if p.starting_time else ""
+            starting_ip = str(p.starting_ip) if p.starting_ip else ""
+            writer.writerow(
+                [user.username, user.first_name, user.last_name, starting_time, starting_ip]
+            )
+
+        self.set_header("Content-Type", "text/csv")
+        self.set_header(
+            "Content-Disposition",
+            f"attachment; filename=participants_{contest_id}.csv",
+        )
+        self.write(output.getvalue())

--- a/cms/server/admin/templates/contest_users.html
+++ b/cms/server/admin/templates/contest_users.html
@@ -7,6 +7,10 @@
 
 {% include "fragments/overload_warning.html" %}
 
+<form action="{{ url("contest", contest.id, "users", "export") }}" method="GET">
+  <button type="submit">Download participants info</button>
+</form>
+
 <form action="{{ url("contest", contest.id, "users", "add") }}" method="POST">
   {{ xsrf_form_html|safe }}
   Add a new user:

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -269,9 +269,22 @@ class StartHandler(ContestHandler):
     @multi_contest
     def post(self):
         participation: Participation = self.current_user
+        try:
+            ip_address = ipaddress.ip_address(self.request.remote_ip)
+        except ValueError:
+            logger.warning(
+                "Invalid IP address provided by Tornado: %s",
+                self.request.remote_ip,
+            )
+            ip_address = None
 
-        logger.info("Starting now for user %s", participation.user.username)
+        logger.info(
+            "Starting now for user %s from %s",
+            participation.user.username,
+            self.request.remote_ip,
+        )
         participation.starting_time = self.timestamp
+        participation.starting_ip = ip_address
         self.sql_session.commit()
 
         self.redirect(self.contest_url())

--- a/cmscontrib/DumpExporter.py
+++ b/cmscontrib/DumpExporter.py
@@ -50,7 +50,7 @@ from sqlalchemy.types import (
     Enum,
     TypeEngine,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, CIDR, JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, CIDR, INET, JSONB
 
 from cms import rmtree, utf8_decoder
 from cms.db import (
@@ -145,8 +145,8 @@ def encode_value(type_: TypeEngine, value: object) -> object:
     elif isinstance(type_, Interval):
         return value.total_seconds()
     elif isinstance(type_, (ARRAY, FilenameSchemaArray)):
-        return list(encode_value(type_.item_type, item) for item in value)
-    elif isinstance(type_, CIDR):
+        return [encode_value(type_.item_type, item) for item in value]
+    elif isinstance(type_, (CIDR, INET)):
         return str(value)
     else:
         raise RuntimeError("Unknown SQLAlchemy column type: %s" % type_)

--- a/cmscontrib/DumpImporter.py
+++ b/cmscontrib/DumpImporter.py
@@ -52,7 +52,7 @@ from sqlalchemy.types import (
     Enum,
     TypeEngine,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, CIDR, JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, CIDR, INET, JSONB
 
 import cms.db as class_hook
 from cms import utf8_decoder
@@ -136,9 +136,11 @@ def decode_value(type_: TypeEngine, value: object) -> object:
     elif isinstance(type_, Interval):
         return timedelta(seconds=value)
     elif isinstance(type_, (ARRAY, FilenameSchemaArray)):
-        return list(decode_value(type_.item_type, item) for item in value)
+        return [decode_value(type_.item_type, item) for item in value]
     elif isinstance(type_, CIDR):
         return ipaddress.ip_network(value)
+    elif isinstance(type_, INET):
+        return ipaddress.ip_address(value)
     else:
         raise RuntimeError(
             "Unknown SQLAlchemy column type: %s" % type_)

--- a/cmscontrib/updaters/update_47.py
+++ b/cmscontrib/updaters/update_47.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Contest Management System - http://cms-dev.github.io/
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""A class to update a dump created by CMS.
+
+Used by DumpImporter and DumpUpdater.
+
+This updater adds the starting_ip field to participations.
+
+"""
+
+
+class Updater:
+
+    def __init__(self, data):
+        assert data["_version"] == 46
+        self.objs = data
+
+    def run(self):
+        for k, v in self.objs.items():
+            if k.startswith("_"):
+                continue
+            if v["_class"] == "Participation":
+                v["starting_ip"] = None
+        return self.objs

--- a/cmscontrib/updaters/update_47.sql
+++ b/cmscontrib/updaters/update_47.sql
@@ -1,0 +1,5 @@
+begin;
+
+alter table participations add starting_ip inet;
+
+rollback; -- change this to: commit;


### PR DESCRIPTION
## Summary
- allow admins to download contest participants with their start time and IP as CSV
- expose a button on the contest users page to trigger the export
- support PostgreSQL INET type so starting IPs are recognized during dumps and ORM mapping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bcrypt')*
- `pip install bcrypt==3.2.0` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68aef050abf08332ad0912c366c17161