### PR TITLE
Add edit capability for announcements

### DIFF
--- a/cms/server/admin/static/aws_style.css
+++ b/cms/server/admin/static/aws_style.css
@@ -531,7 +531,7 @@ th .column-sort {
 .notifications .announcement_remove {
     float: right;
     margin-bottom: -0.143em;
-    width: 6em;
+    width: 10em;
     text-align: center;
     padding: 0;
     font-weight: bold;

--- a/cms/server/admin/templates/announcement.html
+++ b/cms/server/admin/templates/announcement.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% import 'macro/markdown_input.html' as macro_markdown %}
+
+{% block core %}
+<div class="core_title">
+  <h1>Edit announcement</h1>
+</div>
+
+<div class="notifications">
+  <div class="notification communication">
+    <div class="notification_msg">
+      <form method="post" action="{{ url('contest', contest.id, 'announcement', announcement.id) }}">
+        {{ xsrf_form_html|safe }}
+        <div class="notification_subject">
+          <label for="subject">Subject</label>
+          <input type="text" name="subject" id="subject" style="width: 100%" list="task_names_list" autocomplete="off" value="{{ announcement.subject }}">
+          <datalist id="task_names_list">
+            {% for task in contest.tasks %}
+            <option value="{{ task.name }}">
+            {% endfor %}
+          </datalist>
+        </div>
+        <div class="notification_text">
+          <label for="text">Text</label>
+          {{ macro_markdown.markdown_input("text", announcement.text) }}
+        </div>
+        <input type="submit" value="Update announcement" />
+        {{ macro_markdown.markdown_preview() }}
+      </form>
+    </div>
+  </div>
+</div>
+
+{% endblock core %}
+

--- a/cms/server/admin/templates/announcements.html
+++ b/cms/server/admin/templates/announcements.html
@@ -40,6 +40,7 @@
         <div class="notification_msg">
 
           <div class="announcement_remove">
+            <a href="{{ url("contest", contest.id, "announcement", msg.id) }}">Edit</a> |
             <a onclick="CMS.AWSUtils.ajax_delete('{{ url("contest", contest.id, "announcement", msg.id) }}'); ">Remove</a>
           </div>
           <div class="notification_timestamp">{{ msg.timestamp }}</div>

--- a/cms/server/admin/templates/macro/markdown_input.html
+++ b/cms/server/admin/templates/macro/markdown_input.html
@@ -1,5 +1,5 @@
-{% macro markdown_input(name) %}
-<textarea name="{{ name }}" class="markdown_input"></textarea><br/>
+{% macro markdown_input(name, value="") %}
+<textarea name="{{ name }}" class="markdown_input">{{ value }}</textarea><br/>
 You can use Markdown here. URLs are not automatically linked, surround them with &lt;&gt; like &lt;http://example.org&gt;.
 <div class="markdown_preview"></div>
 {% endmacro %}


### PR DESCRIPTION
## Summary
- allow editing announcements in admin interface
- support prefilled markdown inputs and wider action buttons

## Testing
- `flake8 cms/server/admin/handlers/contestannouncement.py`
- `pytest` *(fails: ImportError during collection: ModuleNotFoundError: No module named 'Cryptodome')*


------
https://chatgpt.com/codex/tasks/task_e_68aefe3282d88332813075c59d81b547