### PR TITLE
contest.py: Remove Pascal and C11 from defaults

### DIFF
--- a/cms/db/contest.py
+++ b/cms/db/contest.py
@@ -82,7 +82,7 @@ class Contest(Base):
     languages: list[str] = Column(
         ARRAY(String),
         nullable=False,
-        default=["C11 / gcc", "C++20 / g++", "Pascal / fpc"])
+        default=["C++20 / g++"])
 
     # Whether contestants allowed to download their submissions.
     submissions_download_allowed: bool = Column(


### PR DESCRIPTION
We don't allow Pascal, no reason for it to be the default