### PR TITLE
Allow noninteger timelimit, refactor alerts to Bulma media & deduplicate task templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,9 @@ EOF
 # Create cmsuser user with sudo privileges and access to isolate
 RUN <<EOF
 #!/bin/bash -ex
-    # Need to set user ID manually: otherwise it'd be 1000 on debian
-    # and 1001 on ubuntu.
-    useradd -ms /bin/bash -u 1001 cmsuser
+    # Use a fixed UID that won't collide with the isolate user created
+    # by isolate 2.3 (UID 1000 on debian, 1001 on ubuntu).
+    useradd -ms /bin/bash -u 1100 cmsuser
     usermod -aG sudo cmsuser
     usermod -aG isolate cmsuser
     # Disable sudo password
@@ -83,12 +83,12 @@ COPY --chown=cmsuser:cmsuser install.py constraints.txt /home/cmsuser/src/
 
 WORKDIR /home/cmsuser/src
 
-RUN --mount=type=cache,target=/home/cmsuser/.cache/pip,uid=1001 ./install.py venv
+RUN --mount=type=cache,target=/home/cmsuser/.cache/pip,uid=1100 ./install.py venv
 ENV PATH="/home/cmsuser/cms/bin:$PATH"
 
 COPY --chown=cmsuser:cmsuser . /home/cmsuser/src
 
-RUN --mount=type=cache,target=/home/cmsuser/.cache/pip,uid=1001 ./install.py cms --devel
+RUN --mount=type=cache,target=/home/cmsuser/.cache/pip,uid=1100 ./install.py cms --devel
 
 RUN <<EOF
 #!/bin/bash -ex

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,11 +59,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         >/etc/apt/keyrings/isolate.asc
     apt-get update
     apt-get install -y isolate
-    # isolate 2.3+ creates an 'isolate' user (often UID 1001) which conflicts
-    # with cmsuser. We only need the isolate *group*, so remove the user.
-    # Move the user's primary group away from 'isolate' first so that
-    # userdel does not remove the group along with the user.
-    if id isolate &>/dev/null; then usermod -g nogroup isolate && userdel isolate; fi
     sed -i 's@^cg_root .*@cg_root = /sys/fs/cgroup@' /etc/isolate
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         >/etc/apt/keyrings/isolate.asc
     apt-get update
     apt-get install -y isolate
+    # isolate 2.3+ creates an 'isolate' user (often UID 1001) which conflicts
+    # with cmsuser. We only need the isolate *group*, so remove the user.
+    # Move the user's primary group away from 'isolate' first so that
+    # userdel does not remove the group along with the user.
+    if id isolate &>/dev/null; then usermod -g nogroup isolate && userdel isolate; fi
     sed -i 's@^cg_root .*@cg_root = /sys/fs/cgroup@' /etc/isolate
 EOF
 

--- a/cms/server/admin/static/aws_tp_styles.css
+++ b/cms/server/admin/static/aws_tp_styles.css
@@ -1146,7 +1146,7 @@
    Info Alert (Bulma .message overrides for icon/badge positioning)
    ========================================================================== */
 
-.message .media-content strong {
+.message .media .media-content strong {
     display: block;
     font-size: 0.95rem;
     margin-bottom: 4px;

--- a/cms/server/admin/static/aws_tp_styles.css
+++ b/cms/server/admin/static/aws_tp_styles.css
@@ -1146,16 +1146,7 @@
    Info Alert (Bulma .message overrides for icon/badge positioning)
    ========================================================================== */
 
-.info-alert-icon {
-    flex-shrink: 0;
-    margin-top: 2px;
-}
-
-.info-alert-content {
-    flex: 1;
-}
-
-.info-alert-content strong {
+.message .media-content strong {
     display: block;
     font-size: 0.95rem;
     margin-bottom: 4px;

--- a/cms/server/admin/templates/contest_tasks.html
+++ b/cms/server/admin/templates/contest_tasks.html
@@ -81,7 +81,7 @@ if (addTaskForm) {
     {{ task_search_toolbar(contest.get_tasks()|length, admin.permission_all and unassigned_tasks|length > 0) }}
 
     {% if admin.permission_all and unassigned_tasks|length > 0 %}
-    <div class="tp-filter-card mb-4" id="add-task-panel" style="display:none;">
+    <div class="tp-filter-card mb-4" id="add-task-panel" {% if contest.get_tasks()|length > 0 %}style="display:none;"{% endif %}>
         <form id="add-task-form" class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 12px; flex: 1;" action="{{ url("contest", contest.id, "tasks", "add") }}" method="POST">
             {{ xsrf_form_html|safe }}
             <div class="is-flex-grow-1" style="min-width: 200px;">

--- a/cms/server/admin/templates/contest_tasks.html
+++ b/cms/server/admin/templates/contest_tasks.html
@@ -85,7 +85,7 @@ if (addTaskForm) {
         <form id="add-task-form" class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 12px; flex: 1;" action="{{ url("contest", contest.id, "tasks", "add") }}" method="POST">
             {{ xsrf_form_html|safe }}
             <div class="is-flex-grow-1" style="min-width: 200px;">
-                <select name="task_id" id="task_id" class="searchable-select" style="width: 100%;">
+                <select name="task_id" id="task_id" class="searchable-select" style="width: 100%;" required>
                     <option value="" selected disabled hidden>Choose a task to add...</option>
                     {% for t in unassigned_tasks %}
                     <option value="{{ t.id }}"{% if is_training_day and program_task_ids is defined and t.id not in program_task_ids %} data-not-in-program="true"{% endif %}>

--- a/cms/server/admin/templates/contest_tasks.html
+++ b/cms/server/admin/templates/contest_tasks.html
@@ -49,11 +49,9 @@ if (addTaskForm) {
     <!-- Header -->
     <h1 class="title is-spaced">Tasks</h1>
     <p class="subtitle has-text-grey">
-        {% if is_training_day %}
-        Training Day: <a href="{{ url("contest", contest.id) }}">{{ contest.name }}</a>
-        {% else %}
-        Contest: <a href="{{ url("contest", contest.id) }}">{{ contest.name }}</a>
-        {% endif %}
+        There are {{ contest.get_tasks()|length }} tasks in
+        {% if is_training_day %}training day{% else %}contest{% endif %}
+        <a href="{{ url("contest", contest.id) }}">{{ contest.name }}</a>
     </p>
 
 {% if is_training_day %}
@@ -63,7 +61,7 @@ if (addTaskForm) {
 {% endif %}
 
 {% if contest.start <= timestamp %}
-    <article class="message is-warning" style="margin-bottom: 20px;">
+    <article class="message is-warning mb-4">
         <div class="message-body">
             <article class="media">
                 <figure class="media-left">
@@ -77,14 +75,37 @@ if (addTaskForm) {
     </article>
 {% endif %}
 
-    <!-- Add Task Card -->
-    <div class="tp-filter-card">
-        <label class="tp-filter-label" for="task_id">Add Task:</label>
-        <form id="add-task-form" action="{{ url("contest", contest.id, "tasks", "add") }}" method="POST" style="display: flex; gap: 12px; flex: 1;">
+    <!-- Toolbar: Search + Add -->
+    <div class="level mb-4">
+        <div class="level-left">
+            {% if contest.get_tasks()|length > 0 %}
+            <div class="level-item">
+                <div class="control has-icons-left">
+                    <input type="text" class="input" id="task-search-input" placeholder="Search tasks..." aria-label="Search tasks" oninput="CMS.AWSUtils.filter_table('tasks-table', this.value)" style="width: 300px;">
+                    <span class="icon is-left"><svg width="24" height="24"><use href="#icon-search"/></svg></span>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+        {% if admin.permission_all and unassigned_tasks|length > 0 %}
+        <div class="level-right">
+            <div class="level-item">
+                <button type="button" class="button is-primary" onclick="var p=document.getElementById('add-task-panel');p.style.display=p.style.display==='none'?'':'none'">
+                    <svg class="icon is-small"><use href="#icon-plus"/></svg>
+                    <span>Add Task</span>
+                </button>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
+    {% if admin.permission_all and unassigned_tasks|length > 0 %}
+    <div class="tp-filter-card mb-4" id="add-task-panel" style="display:none;">
+        <form id="add-task-form" class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 12px; flex: 1;" action="{{ url("contest", contest.id, "tasks", "add") }}" method="POST">
             {{ xsrf_form_html|safe }}
-            <div style="flex-grow: 1;">
+            <div class="is-flex-grow-1" style="min-width: 200px;">
                 <select name="task_id" id="task_id" class="searchable-select" style="width: 100%;">
-                    <option value="" selected disabled hidden>Select a task...</option>
+                    <option value="" selected disabled hidden>Choose a task to add...</option>
                     {% for t in unassigned_tasks %}
                     <option value="{{ t.id }}"{% if is_training_day and program_task_ids is defined and t.id not in program_task_ids %} data-not-in-program="true"{% endif %}>
                         {{ t.name }}{% if is_training_day and program_task_ids is defined and t.id not in program_task_ids %} (not in training program){% endif %}
@@ -92,16 +113,13 @@ if (addTaskForm) {
                     {% endfor %}
                 </select>
             </div>
-            <button type="submit" class="button is-primary" {% if not admin.permission_all %}disabled{% endif %} style="white-space: nowrap;">
-                <span>Add Task</span>
+            <button type="submit" class="button is-primary">
+                <svg class="icon is-small"><use href="#icon-plus"/></svg>
+                <span>Add</span>
             </button>
         </form>
     </div>
-
-    <!-- Tasks Table -->
-    <div class="tp-section-header">
-        <h2>All Tasks ({{ contest.get_tasks()|length }})</h2>
-    </div>
+    {% endif %}
 
     {% if contest.get_tasks() %}
     <form action="{{ url("contest", contest.id, "tasks") }}" method="POST" id="tasks-form">

--- a/cms/server/admin/templates/contest_tasks.html
+++ b/cms/server/admin/templates/contest_tasks.html
@@ -64,13 +64,15 @@ if (addTaskForm) {
 
 {% if contest.start <= timestamp %}
     <article class="message is-warning" style="margin-bottom: 20px;">
-        <div class="message-body is-flex is-gap-2">
-            <div class="info-alert-icon">
-                <svg class="icon is-small"><use href="#icon-alert-triangle"/></svg>
-            </div>
-            <div class="info-alert-content">
-                <div>The contest is visible to contestants, tasks added can be seen.</div>
-            </div>
+        <div class="message-body">
+            <article class="media">
+                <figure class="media-left">
+                    <svg class="icon is-small"><use href="#icon-alert-triangle"/></svg>
+                </figure>
+                <div class="media-content">
+                    <div>The contest is visible to contestants, tasks added can be seen.</div>
+                </div>
+            </article>
         </div>
     </article>
 {% endif %}

--- a/cms/server/admin/templates/contest_tasks.html
+++ b/cms/server/admin/templates/contest_tasks.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% from "fragments/task_search_toolbar.html" import task_search_toolbar %}
+{% from "fragments/task_reorder_script.html" import task_reorder_script %}
 
 {% block js_init %}
 {% if is_training_day %}
@@ -76,28 +78,7 @@ if (addTaskForm) {
 {% endif %}
 
     <!-- Toolbar: Search + Add -->
-    <div class="level mb-4">
-        <div class="level-left">
-            {% if contest.get_tasks()|length > 0 %}
-            <div class="level-item">
-                <div class="control has-icons-left">
-                    <input type="text" class="input" id="task-search-input" placeholder="Search tasks..." aria-label="Search tasks" oninput="CMS.AWSUtils.filter_table('tasks-table', this.value)" style="width: 300px;">
-                    <span class="icon is-left"><svg width="24" height="24"><use href="#icon-search"/></svg></span>
-                </div>
-            </div>
-            {% endif %}
-        </div>
-        {% if admin.permission_all and unassigned_tasks|length > 0 %}
-        <div class="level-right">
-            <div class="level-item">
-                <button type="button" class="button is-primary" onclick="var p=document.getElementById('add-task-panel');p.style.display=p.style.display==='none'?'':'none'">
-                    <svg class="icon is-small"><use href="#icon-plus"/></svg>
-                    <span>Add Task</span>
-                </button>
-            </div>
-        </div>
-        {% endif %}
-    </div>
+    {{ task_search_toolbar(contest.get_tasks()|length, admin.permission_all and unassigned_tasks|length > 0) }}
 
     {% if admin.permission_all and unassigned_tasks|length > 0 %}
     <div class="tp-filter-card mb-4" id="add-task-panel" style="display:none;">
@@ -240,39 +221,8 @@ if (addTaskForm) {
     // Only initialize drag-drop if tasks table exists
     var tasksTbody = document.getElementById('tasks-tbody');
     if (tasksTbody) {
-        AdminTableUtils.initDragDropReorder({
-            tbodyId: 'tasks-tbody',
-            rowSelector: 'tr',
-            rowIdAttr: 'task-id',
-            colSpan: colSpan,
-            confirmMessage: 'Save the new task order?',
-            onSave: function(orderedIds) {
-                var order = orderedIds.map(function(item) {
-                    return { task_id: item.id, new_num: item.position };
-                });
-                var form = document.getElementById('tasks-form');
-                var reorderInput = document.getElementById('reorder-data');
-                reorderInput.value = JSON.stringify(order);
-
-                var operationInput = form.querySelector('input[name="operation"]');
-                if (!operationInput) {
-                    operationInput = document.createElement('input');
-                    operationInput.type = 'hidden';
-                    operationInput.name = 'operation';
-                    form.appendChild(operationInput);
-                }
-                operationInput.value = 'reorder';
-                form.submit();
-            }
-        });
+        {{ task_reorder_script(col_span='colSpan') }}
     }
-
-  $(document).ready(function() {
-      var table = $("#tasks-table");
-      if (table.length) {
-          CMS.AWSUtils.init_table_sort(table, false, -1);
-      }
-  });
 })();
 </script>
 {% endblock core %}

--- a/cms/server/admin/templates/delays_and_extra_times.html
+++ b/cms/server/admin/templates/delays_and_extra_times.html
@@ -39,7 +39,7 @@ CMS.AWSFormUtils.initTagify({
 {% endif %}
 
 
-CMS.AWSUtils.init_table_sort($("#participations-table"), false, -1);
+CMS.AWSUtils.init_table_sort($("#participations-table"), false, -1, true);
 
 {% endblock js_init %}
 

--- a/cms/server/admin/templates/fragments/dataset_form_fields.html
+++ b/cms/server/admin/templates/fragments/dataset_form_fields.html
@@ -13,7 +13,7 @@
     </div>
     <div class="modal__form-group">
         <label for="{{ id_prefix }}-time-limit">Time limit (seconds)</label>
-        <input type="text" id="{{ id_prefix }}-time-limit" name="time_limit" value="{{ dataset.time_limit if dataset and dataset.time_limit is not none else ('' if dataset else '1') }}" />
+        <input type="number" step="any" id="{{ id_prefix }}-time-limit" name="time_limit" value="{{ dataset.time_limit if dataset and dataset.time_limit is not none else ('' if dataset else '1') }}" />
     </div>
     <div class="modal__form-group">
         <label for="{{ id_prefix }}-memory-limit">Memory limit (MiB)</label>

--- a/cms/server/admin/templates/fragments/info_alert.html
+++ b/cms/server/admin/templates/fragments/info_alert.html
@@ -9,30 +9,32 @@
 #}
 {% macro alert(title, message, items=none, type='warning') %}
 <article class="message is-{{ type }}">
-    <div class="message-body is-flex is-gap-2">
-        <div class="info-alert-icon">
-            {% if type == 'warning' %}
-            <svg class="icon"><use href="#icon-alert-triangle"/></svg>
-            {% else %}
-            <svg class="icon"><use href="#icon-info"/></svg>
-            {% endif %}
-        </div>
-        <div class="info-alert-content">
-            <strong>{{ title }}</strong>
-            <div>{{ message }}</div>
-            {% if items %}
-            <div class="info-alert-items">
-                {% for item in items %}
-                <a href="{{ item.url }}" class="info-alert-badge">
-                    {{ item.label }}
-                    {% if item.count is defined and item.count %}
-                    <span class="info-alert-count">{{ item.count }}</span>
-                    {% endif %}
-                </a>
-                {% endfor %}
+    <div class="message-body">
+        <article class="media">
+            <figure class="media-left">
+                {% if type == 'warning' %}
+                <svg class="icon"><use href="#icon-alert-triangle"/></svg>
+                {% else %}
+                <svg class="icon"><use href="#icon-info"/></svg>
+                {% endif %}
+            </figure>
+            <div class="media-content">
+                <strong>{{ title }}</strong>
+                <div>{{ message }}</div>
+                {% if items %}
+                <div class="info-alert-items">
+                    {% for item in items %}
+                    <a href="{{ item.url }}" class="info-alert-badge">
+                        {{ item.label }}
+                        {% if item.count is defined and item.count %}
+                        <span class="info-alert-count">{{ item.count }}</span>
+                        {% endif %}
+                    </a>
+                    {% endfor %}
+                </div>
+                {% endif %}
             </div>
-            {% endif %}
-        </div>
+        </article>
     </div>
 </article>
 {% endmacro %}

--- a/cms/server/admin/templates/fragments/task_reorder_script.html
+++ b/cms/server/admin/templates/fragments/task_reorder_script.html
@@ -1,0 +1,40 @@
+{#
+  Shared drag-drop reorder and table sort initialization for task list pages.
+
+  Parameters:
+  - col_span: Number of columns in the table (used for drag placeholder)
+#}
+{% macro task_reorder_script(col_span) %}
+AdminTableUtils.initDragDropReorder({
+    tbodyId: 'tasks-tbody',
+    rowSelector: 'tr',
+    rowIdAttr: 'task-id',
+    colSpan: {{ col_span }},
+    confirmMessage: 'Save the new task order?',
+    onSave: function(orderedIds) {
+        var order = orderedIds.map(function(item) {
+            return { task_id: item.id, new_num: item.position };
+        });
+        var form = document.getElementById('tasks-form');
+        var reorderInput = document.getElementById('reorder-data');
+        reorderInput.value = JSON.stringify(order);
+
+        var operationInput = form.querySelector('input[name="operation"]');
+        if (!operationInput) {
+            operationInput = document.createElement('input');
+            operationInput.type = 'hidden';
+            operationInput.name = 'operation';
+            form.appendChild(operationInput);
+        }
+        operationInput.value = 'reorder';
+        form.submit();
+    }
+});
+
+$(document).ready(function() {
+    var table = $("#tasks-table");
+    if (table.length) {
+        CMS.AWSUtils.init_table_sort(table, false, -1);
+    }
+});
+{% endmacro %}

--- a/cms/server/admin/templates/fragments/task_reorder_script.html
+++ b/cms/server/admin/templates/fragments/task_reorder_script.html
@@ -34,7 +34,7 @@ AdminTableUtils.initDragDropReorder({
 $(document).ready(function() {
     var table = $("#tasks-table");
     if (table.length) {
-        CMS.AWSUtils.init_table_sort(table, false, -1);
+        CMS.AWSUtils.init_table_sort(table, false, -1, true);
     }
 });
 {% endmacro %}

--- a/cms/server/admin/templates/fragments/task_search_toolbar.html
+++ b/cms/server/admin/templates/fragments/task_search_toolbar.html
@@ -1,0 +1,31 @@
+{#
+  Shared toolbar for task list pages: search input + "Add Task" toggle button.
+
+  Parameters:
+  - task_count: Number of tasks currently in the list
+  - show_add_button: Whether to show the Add Task button (requires permission + unassigned tasks)
+#}
+{% macro task_search_toolbar(task_count, show_add_button=false) %}
+<div class="level mb-4">
+    <div class="level-left">
+        {% if task_count > 0 %}
+        <div class="level-item">
+            <div class="control has-icons-left">
+                <input type="text" class="input" id="task-search-input" placeholder="Search tasks..." aria-label="Search tasks" oninput="CMS.AWSUtils.filter_table('tasks-table', this.value)" style="width: 300px;">
+                <span class="icon is-left"><svg width="24" height="24"><use href="#icon-search"/></svg></span>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+    {% if show_add_button %}
+    <div class="level-right">
+        <div class="level-item">
+            <button type="button" class="button is-primary" onclick="var p=document.getElementById('add-task-panel');p.style.display=p.style.display==='none'?'':'none'">
+                <svg class="icon is-small"><use href="#icon-plus"/></svg>
+                <span>Add Task</span>
+            </button>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endmacro %}

--- a/cms/server/admin/templates/fragments/task_search_toolbar.html
+++ b/cms/server/admin/templates/fragments/task_search_toolbar.html
@@ -6,7 +6,7 @@
   - show_add_button: Whether to show the Add Task button (requires permission + unassigned tasks)
 #}
 {% macro task_search_toolbar(task_count, show_add_button=false) %}
-<div class="level mb-4">
+<div class="level mb-4 is-mobile">
     <div class="level-left">
         {% if task_count > 0 %}
         <div class="level-item">

--- a/cms/server/admin/templates/fragments/task_search_toolbar.html
+++ b/cms/server/admin/templates/fragments/task_search_toolbar.html
@@ -20,7 +20,7 @@
     {% if show_add_button %}
     <div class="level-right">
         <div class="level-item">
-            <button type="button" class="button is-primary" onclick="var p=document.getElementById('add-task-panel');p.style.display=p.style.display==='none'?'':'none'">
+            <button type="button" class="button is-primary" aria-controls="add-task-panel" aria-expanded="{{ 'true' if task_count == 0 else 'false' }}" onclick="var p=document.getElementById('add-task-panel'),v=p.style.display==='none';p.style.display=v?'':'none';this.setAttribute('aria-expanded',v)">
                 <svg class="icon is-small"><use href="#icon-plus"/></svg>
                 <span>Add Task</span>
             </button>

--- a/cms/server/admin/templates/macro/bulma_file_input.html
+++ b/cms/server/admin/templates/macro/bulma_file_input.html
@@ -17,7 +17,7 @@
 </div>
 {% endmacro %}
 
-{% macro form_field(name, label, value='', type='text', placeholder='', required=False, icon=None, hint=None, info_tooltip=None, autocomplete=None, input_id=None, rows=3) %}
+{% macro form_field(name, label, value='', type='text', placeholder='', required=False, icon=None, hint=None, info_tooltip=None, autocomplete=None, input_id=None, rows=3, step=None) %}
 {% set field_id = input_id or name %}
 <div class="field">
     <label class="label" for="{{ field_id }}">
@@ -51,6 +51,7 @@
                value="{{ value }}"
                placeholder="{{ placeholder }}"
                {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
+               {% if step %}step="{{ step }}"{% endif %}
                {% if required %}required{% endif %}>
         {% if icon %}
         <span class="icon is-small is-left">

--- a/cms/server/admin/templates/student_tasks.html
+++ b/cms/server/admin/templates/student_tasks.html
@@ -58,7 +58,7 @@
         {% if admin.permission_all and available_tasks|length > 0 %}
         <div class="level-right">
             <div class="level-item">
-                <button type="button" class="button is-primary" onclick="var p=document.getElementById('add-task-panel');p.style.display=p.style.display==='none'?'':'none'">
+                <button type="button" class="button is-primary" aria-controls="add-task-panel" aria-expanded="{{ 'true' if student_tasks|length == 0 else 'false' }}" onclick="var p=document.getElementById('add-task-panel'),v=p.style.display==='none';p.style.display=v?'':'none';this.setAttribute('aria-expanded',v)">
                     <svg class="icon is-small"><use href="#icon-plus"/></svg>
                     <span>Add Task</span>
                 </button>
@@ -68,11 +68,11 @@
     </div>
 
     {% if admin.permission_all and available_tasks|length > 0 %}
-    <div class="tp-filter-card mb-4" id="add-task-panel" style="display:none;">
+    <div class="tp-filter-card mb-4" id="add-task-panel" {% if student_tasks|length > 0 %}style="display:none;"{% endif %}>
         <form class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 12px; flex: 1;" enctype="multipart/form-data" action="{{ url("training_program", training_program.id, "student", selected_user.id, "tasks", "add") }}" method="POST">
             {{ xsrf_form_html|safe }}
             <div class="is-flex-grow-1" style="min-width: 200px;">
-                <select name="task_id" id="task_selector" class="searchable-select" style="width: 100%;">
+                <select name="task_id" id="task_selector" class="searchable-select" style="width: 100%;" required>
                     <option value="" selected disabled hidden>Choose a task to add...</option>
                     {% for task in available_tasks %}
                     <option value="{{ task.id }}">{{ task.name }} - {{ task.title }}</option>
@@ -216,7 +216,7 @@
 <script>
 // Table sorting using CMS.AWSUtils
 $(document).ready(function() {
-    CMS.AWSUtils.init_table_sort($("#student-tasks-table"), false, 0);
+    CMS.AWSUtils.init_table_sort($("#student-tasks-table"), false, 0, true);
 });
 </script>
 {% endblock core %}

--- a/cms/server/admin/templates/student_tasks.html
+++ b/cms/server/admin/templates/student_tasks.html
@@ -36,36 +36,56 @@
     </div>
 
     <!-- Header -->
-    <h1 class="title is-spaced">Task Archive: <a href="{{ url("user", selected_user.id) }}">{{ selected_user.username }}</a></h1>
+    <h1 class="title is-spaced">Task Archive</h1>
     <p class="subtitle has-text-grey">
-        Program: <a href="{{ url("training_program", training_program.id) }}">{{ training_program.name }}</a>
+        <a href="{{ url("user", selected_user.id) }}">{{ selected_user.username }}</a>
+        has {{ student_tasks|length }} assigned tasks in
+        <a href="{{ url("training_program", training_program.id) }}">{{ training_program.name }}</a>
     </p>
 
-    <!-- Add Task Card -->
-    <div class="tp-filter-card">
-        <label class="tp-filter-label" for="task_selector">Manual Task Assignment:</label>
-        <form enctype="multipart/form-data" action="{{ url("training_program", training_program.id, "student", selected_user.id, "tasks", "add") }}" method="POST" style="display: flex; gap: 12px;">
-            {{ xsrf_form_html|safe }}
+    <!-- Toolbar: Search + Add -->
+    <div class="level mb-4">
+        <div class="level-left">
+            {% if student_tasks|length > 0 %}
+            <div class="level-item">
+                <div class="control has-icons-left">
+                    <input type="text" class="input" placeholder="Search tasks..." aria-label="Search tasks" oninput="CMS.AWSUtils.filter_table('student-tasks-table', this.value)" style="width: 300px;">
+                    <span class="icon is-left"><svg width="24" height="24"><use href="#icon-search"/></svg></span>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+        {% if admin.permission_all and available_tasks|length > 0 %}
+        <div class="level-right">
+            <div class="level-item">
+                <button type="button" class="button is-primary" onclick="var p=document.getElementById('add-task-panel');p.style.display=p.style.display==='none'?'':'none'">
+                    <svg class="icon is-small"><use href="#icon-plus"/></svg>
+                    <span>Add Task</span>
+                </button>
+            </div>
+        </div>
+        {% endif %}
+    </div>
 
-            <div style="flex-grow: 1;">
-                <select name="task_id" id="task_selector" class="searchable-select" placeholder="Search for a task..." style="width: 100%;">
-                    <option value="" selected disabled hidden>Select a task...</option>
+    {% if admin.permission_all and available_tasks|length > 0 %}
+    <div class="tp-filter-card mb-4" id="add-task-panel" style="display:none;">
+        <form class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 12px; flex: 1;" enctype="multipart/form-data" action="{{ url("training_program", training_program.id, "student", selected_user.id, "tasks", "add") }}" method="POST">
+            {{ xsrf_form_html|safe }}
+            <div class="is-flex-grow-1" style="min-width: 200px;">
+                <select name="task_id" id="task_selector" class="searchable-select" style="width: 100%;">
+                    <option value="" selected disabled hidden>Choose a task to add...</option>
                     {% for task in available_tasks %}
                     <option value="{{ task.id }}">{{ task.name }} - {{ task.title }}</option>
                     {% endfor %}
                 </select>
             </div>
-
-            <button type="submit" class="button is-primary" {% if not admin.permission_all %}disabled{% endif %} style="white-space: nowrap;">
-                <span>Add Task</span>
+            <button type="submit" class="button is-primary">
+                <svg class="icon is-small"><use href="#icon-plus"/></svg>
+                <span>Add</span>
             </button>
         </form>
     </div>
-
-    <!-- List Header -->
-    <div class="tp-section-header">
-        <h2>Assigned Tasks ({{ student_tasks|length }})</h2>
-    </div>
+    {% endif %}
 
     <!-- Table -->
     <div class="table-container">

--- a/cms/server/admin/templates/student_tasks.html
+++ b/cms/server/admin/templates/student_tasks.html
@@ -44,7 +44,7 @@
     </p>
 
     <!-- Toolbar: Search + Add -->
-    <div class="level mb-4">
+    <div class="level mb-4 is-mobile">
         <div class="level-left">
             {% if student_tasks|length > 0 %}
             <div class="level-item">

--- a/cms/server/admin/templates/task.html
+++ b/cms/server/admin/templates/task.html
@@ -891,7 +891,7 @@ window.submitSubtaskNameEdit = function(editId, displayId, actionUrl) {
                             <div class="fixed-grid has-2-cols">
                               <div class="grid">
                                 <div class="cell is-col-span-1">
-                                    {{ form_field('time_limit_' ~ dataset.id, 'Time limit (seconds)', dataset.time_limit if dataset.time_limit is not none else '', type='number', info_tooltip='Total maximum time for each evaluation, in seconds.') }}
+                                    {{ form_field('time_limit_' ~ dataset.id, 'Time limit (seconds)', dataset.time_limit if dataset.time_limit is not none else '', type='number', step='any', info_tooltip='Total maximum time for each evaluation, in seconds.') }}
                                 </div>
                                 <div class="cell is-col-span-1">
                                     {{ form_field('memory_limit_' ~ dataset.id, 'Memory limit (MiB)', dataset.memory_limit // (1024 * 1024) if dataset.memory_limit is not none else '', type='number', info_tooltip='Total maximum memory usage for each evaluation, in MiB (2^20 bytes).') }}
@@ -1046,28 +1046,32 @@ window.submitSubtaskNameEdit = function(editId, displayId, actionUrl) {
 
                         {% if ds_ns.any_validator_running %}
                         <article class="message is-info" style="margin-bottom: 16px;">
-                            <div class="message-body is-flex is-gap-2">
-                                <div class="info-alert-icon">
-                                    <svg class="icon is-small"><use href="#icon-cpu"/></svg>
-                                </div>
-                                <div class="info-alert-content">
-                                    <div>One or more validators are currently running. Refresh the page to see updated results.</div>
-                                </div>
+                            <div class="message-body">
+                                <article class="media">
+                                    <figure class="media-left">
+                                        <svg class="icon is-small"><use href="#icon-cpu"/></svg>
+                                    </figure>
+                                    <div class="media-content">
+                                        <div>One or more validators are currently running. Refresh the page to see updated results.</div>
+                                    </div>
+                                </article>
                             </div>
                         </article>
                         {% elif ds_ns.total_not_validated > 0 %}
                         <article class="message is-warning" style="margin-bottom: 16px;">
-                            <div class="message-body is-flex is-gap-2">
-                                <div class="info-alert-icon">
-                                    <svg class="icon is-small"><use href="#icon-alert-triangle"/></svg>
-                                </div>
-                                <div class="info-alert-content">
-                                    <div>{{ ds_ns.total_not_validated }} testcase(s) have not been validated.
-                                    {% if admin.permission_all %}
-                                        <button type="button" onclick="document.getElementById('rerun_validators_form_{{ dataset.id }}').submit();" style="font-weight: 600; background: none; border: none; color: inherit; text-decoration: underline; cursor: pointer;">Rerun validators</button>
-                                    {% endif %}
+                            <div class="message-body">
+                                <article class="media">
+                                    <figure class="media-left">
+                                        <svg class="icon is-small"><use href="#icon-alert-triangle"/></svg>
+                                    </figure>
+                                    <div class="media-content">
+                                        <div>{{ ds_ns.total_not_validated }} testcase(s) have not been validated.
+                                        {% if admin.permission_all %}
+                                            <button type="button" onclick="document.getElementById('rerun_validators_form_{{ dataset.id }}').submit();" style="font-weight: 600; background: none; border: none; color: inherit; text-decoration: underline; cursor: pointer;">Rerun validators</button>
+                                        {% endif %}
+                                        </div>
                                     </div>
-                                </div>
+                                </article>
                             </div>
                         </article>
                         {% endif %}

--- a/cms/server/admin/templates/training_program_tasks.html
+++ b/cms/server/admin/templates/training_program_tasks.html
@@ -5,34 +5,55 @@
     <!-- Header -->
     <h1 class="title is-spaced">Tasks</h1>
     <p class="subtitle has-text-grey">
-        Program: <a href="{{ url("training_program", training_program.id) }}">{{ training_program.name }}</a>
+        There are {{ training_program.managing_contest.tasks|length }} tasks in
+        <a href="{{ url("training_program", training_program.id) }}">{{ training_program.name }}</a>
     </p>
 
     {% include "fragments/overload_warning.html" %}
 
-    <!-- Add Task Card -->
-    <div class="tp-filter-card">
-        <label class="tp-filter-label" for="task_id">Add Task:</label>
-        <form action="{{ url("training_program", training_program.id, "tasks", "add") }}" method="POST" style="display: flex; gap: 12px; flex: 1;">
+    <!-- Toolbar: Search + Add -->
+    <div class="level mb-4">
+        <div class="level-left">
+            {% if training_program.managing_contest.tasks|length > 0 %}
+            <div class="level-item">
+                <div class="control has-icons-left">
+                    <input type="text" class="input" id="task-search-input" placeholder="Search tasks..." aria-label="Search tasks" oninput="CMS.AWSUtils.filter_table('tasks-table', this.value)" style="width: 300px;">
+                    <span class="icon is-left"><svg width="24" height="24"><use href="#icon-search"/></svg></span>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+        {% if admin.permission_all and unassigned_tasks|length > 0 %}
+        <div class="level-right">
+            <div class="level-item">
+                <button type="button" class="button is-primary" onclick="var p=document.getElementById('add-task-panel');p.style.display=p.style.display==='none'?'':'none'">
+                    <svg class="icon is-small"><use href="#icon-plus"/></svg>
+                    <span>Add Task</span>
+                </button>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
+    {% if admin.permission_all and unassigned_tasks|length > 0 %}
+    <div class="tp-filter-card mb-4" id="add-task-panel" style="display:none;">
+        <form class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 12px; flex: 1;" action="{{ url("training_program", training_program.id, "tasks", "add") }}" method="POST">
             {{ xsrf_form_html|safe }}
-            <div style="flex-grow: 1;">
+            <div class="is-flex-grow-1" style="min-width: 200px;">
                 <select name="task_id" id="task_id" class="searchable-select" style="width: 100%;">
-                    <option value="" selected disabled hidden>Select a task...</option>
+                    <option value="" selected disabled hidden>Choose a task to add...</option>
                     {% for t in unassigned_tasks %}
                     <option value="{{ t.id }}">{{ t.name }} - {{ t.title }}</option>
                     {% endfor %}
                 </select>
             </div>
-            <button type="submit" class="button is-primary" {% if not admin.permission_all %}disabled{% endif %} style="white-space: nowrap;">
-                <span>Add Task</span>
+            <button type="submit" class="button is-primary">
+                <svg class="icon is-small"><use href="#icon-plus"/></svg>
+                <span>Add</span>
             </button>
         </form>
     </div>
-
-    <!-- Tasks Table -->
-    <div class="tp-section-header">
-        <h2>All Tasks ({{ training_program.managing_contest.tasks|length }})</h2>
-    </div>
+    {% endif %}
 
     {% if training_program.managing_contest.tasks %}
     <form action="{{ url("training_program", training_program.id, "tasks") }}" method="POST" id="tasks-form">

--- a/cms/server/admin/templates/training_program_tasks.html
+++ b/cms/server/admin/templates/training_program_tasks.html
@@ -17,7 +17,7 @@
     {{ task_search_toolbar(training_program.managing_contest.tasks|length, admin.permission_all and unassigned_tasks|length > 0) }}
 
     {% if admin.permission_all and unassigned_tasks|length > 0 %}
-    <div class="tp-filter-card mb-4" id="add-task-panel" style="display:none;">
+    <div class="tp-filter-card mb-4" id="add-task-panel" {% if training_program.managing_contest.tasks|length > 0 %}style="display:none;"{% endif %}>
         <form class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 12px; flex: 1;" action="{{ url("training_program", training_program.id, "tasks", "add") }}" method="POST">
             {{ xsrf_form_html|safe }}
             <div class="is-flex-grow-1" style="min-width: 200px;">

--- a/cms/server/admin/templates/training_program_tasks.html
+++ b/cms/server/admin/templates/training_program_tasks.html
@@ -21,7 +21,7 @@
         <form class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 12px; flex: 1;" action="{{ url("training_program", training_program.id, "tasks", "add") }}" method="POST">
             {{ xsrf_form_html|safe }}
             <div class="is-flex-grow-1" style="min-width: 200px;">
-                <select name="task_id" id="task_id" class="searchable-select" style="width: 100%;">
+                <select name="task_id" id="task_id" class="searchable-select" style="width: 100%;" required>
                     <option value="" selected disabled hidden>Choose a task to add...</option>
                     {% for t in unassigned_tasks %}
                     <option value="{{ t.id }}">{{ t.name }} - {{ t.title }}</option>

--- a/cms/server/admin/templates/training_program_tasks.html
+++ b/cms/server/admin/templates/training_program_tasks.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% from "fragments/task_search_toolbar.html" import task_search_toolbar %}
+{% from "fragments/task_reorder_script.html" import task_reorder_script %}
 
 {% block core %}
 <div class="content-constraint" style="max-width: 900px;">
@@ -12,28 +14,7 @@
     {% include "fragments/overload_warning.html" %}
 
     <!-- Toolbar: Search + Add -->
-    <div class="level mb-4">
-        <div class="level-left">
-            {% if training_program.managing_contest.tasks|length > 0 %}
-            <div class="level-item">
-                <div class="control has-icons-left">
-                    <input type="text" class="input" id="task-search-input" placeholder="Search tasks..." aria-label="Search tasks" oninput="CMS.AWSUtils.filter_table('tasks-table', this.value)" style="width: 300px;">
-                    <span class="icon is-left"><svg width="24" height="24"><use href="#icon-search"/></svg></span>
-                </div>
-            </div>
-            {% endif %}
-        </div>
-        {% if admin.permission_all and unassigned_tasks|length > 0 %}
-        <div class="level-right">
-            <div class="level-item">
-                <button type="button" class="button is-primary" onclick="var p=document.getElementById('add-task-panel');p.style.display=p.style.display==='none'?'':'none'">
-                    <svg class="icon is-small"><use href="#icon-plus"/></svg>
-                    <span>Add Task</span>
-                </button>
-            </div>
-        </div>
-        {% endif %}
-    </div>
+    {{ task_search_toolbar(training_program.managing_contest.tasks|length, admin.permission_all and unassigned_tasks|length > 0) }}
 
     {% if admin.permission_all and unassigned_tasks|length > 0 %}
     <div class="tp-filter-card mb-4" id="add-task-panel" style="display:none;">
@@ -178,40 +159,8 @@
         });
     });
 
-// Drag and drop reordering using shared utility
-AdminTableUtils.initDragDropReorder({
-    tbodyId: 'tasks-tbody',
-    rowSelector: 'tr',
-    rowIdAttr: 'task-id',
-    colSpan: 4,
-    confirmMessage: 'Save the new task order?',
-    onSave: function(orderedIds) {
-        var order = orderedIds.map(function(item) {
-            return { task_id: item.id, new_num: item.position };
-        });
-        var form = document.getElementById('tasks-form');
-        var reorderInput = document.getElementById('reorder-data');
-        reorderInput.value = JSON.stringify(order);
-
-        var operationInput = form.querySelector('input[name="operation"]');
-        if (!operationInput) {
-            operationInput = document.createElement('input');
-            operationInput.type = 'hidden';
-            operationInput.name = 'operation';
-            form.appendChild(operationInput);
-        }
-        operationInput.value = 'reorder';
-        form.submit();
-    }
-});
-
-    // Table sorting using CMS.AWSUtils
-    $(document).ready(function() {
-        var table = $("#tasks-table");
-        if (table.length) {
-            CMS.AWSUtils.init_table_sort(table, false, -1);
-        }
-    });
+// Drag and drop reordering + table sorting using shared utility
+    {{ task_reorder_script(4) }}
 })();
 </script>
 {% endblock core %}

--- a/cms/server/admin/templates/training_program_training_days.html
+++ b/cms/server/admin/templates/training_program_training_days.html
@@ -493,8 +493,8 @@ AdminTableUtils.initDragDropReorder({
 
 // Initialize table sorting for both tables using CMS.AWSUtils
 $(document).ready(function() {
-    CMS.AWSUtils.init_table_sort($("#training-days-table"), false, -1);
-    CMS.AWSUtils.init_table_sort($("#archived-training-days-table"), false, 3);
+    CMS.AWSUtils.init_table_sort($("#training-days-table"), false, -1, true);
+    CMS.AWSUtils.init_table_sort($("#archived-training-days-table"), false, 3, true);
 });
 
 // Scoreboard Sharing Modal


### PR DESCRIPTION
## Summary

Four groups of changes:

1. **Refactor alert layout to Bulma media component** — replaces custom `.info-alert-icon` / `.info-alert-content` flex-based divs with Bulma's `<article class="media">` + `<figure class="media-left">` + `<div class="media-content">` pattern across all alert templates (`info_alert.html`, `contest_tasks.html`, `task.html`). Removes the now-unused custom CSS classes and replaces with a scoped `.message .media .media-content strong` selector.

2. **Allow decimal time limits** — adds an optional `step` parameter to the `form_field` macro and passes `step='any'` on the time limit input, enabling non-integer values (e.g. `1.5` seconds). Also changes the dataset create/clone modal time limit input from `type="text"` to `type="number" step="any"` for consistency.

3. **Fix isolate UID collision in Dockerfile** — isolate 2.3 creates an `isolate` system user during package install (UID 1000 on debian:bookworm, UID 1001 on ubuntu:noble). The previous UID 1001 for `cmsuser` collided on ubuntu:noble. Changed `cmsuser` to UID 1100 (and the corresponding pip cache mount UIDs) so it never conflicts with the isolate user on either distro. The isolate user is preserved, which the sandbox workers require.

4. **Extract shared task-list template fragments** — duplicate code between `contest_tasks.html` and `training_program_tasks.html` (~42 lines each for toolbar + drag-drop reorder JS) is extracted into two reusable Jinja2 macros:
   - `fragments/task_search_toolbar.html` — search input + "Add Task" toggle button
   - `fragments/task_reorder_script.html` — `AdminTableUtils.initDragDropReorder` config + `CMS.AWSUtils.init_table_sort` init

   Both pages now import and call these macros instead of duplicating the code. This resolves the SonarQube duplication gate failure (was 30.6%, threshold ≤ 3%).

5. **Redesigned "Add Task" UX across task list pages** — the add-task form is now hidden behind a collapsible panel toggled by an "Add Task" button in the toolbar (shown only when there are unassigned tasks and the user has permission). Applied consistently to `contest_tasks.html`, `training_program_tasks.html`, and `student_tasks.html`. Subtitles now show task counts (e.g. "There are 5 tasks in …").

### Updates since last revision
- **Dockerfile UID fix (final approach)**: Moved `cmsuser` to UID 1100 instead of deleting the isolate user. The earlier approach of removing the isolate user broke sandbox workers, causing functional test timeouts. UID 1100 avoids collision on both debian and ubuntu without disrupting isolate.
- Narrowed CSS selector from `.message .media-content strong` to `.message .media .media-content strong` to avoid unintentionally styling `<strong>` tags in other `.media-content` contexts outside alerts.
- Changed dataset create/clone modal time_limit input (`dataset_form_fields.html`) from `type="text"` to `type="number" step="any"` so it matches the main form behavior.
- Extracted shared Jinja2 macros (`task_search_toolbar`, `task_reorder_script`) to eliminate template code duplication flagged by SonarQube.

## Review & Testing Checklist for Human

- [ ] **Verify task list pages render correctly**: The toolbar (search + add button) and drag-drop reorder JS are now rendered via shared macros. Visit both a contest tasks page and a training program tasks page to confirm search, add-task toggle, drag-drop reorder, and table sorting all still work.
- [ ] **Check `col_span` handling in `task_reorder_script`**: In `contest_tasks.html`, the macro is called with `col_span='colSpan'` (a JS variable name) so it renders as `colSpan: colSpan`. In `training_program_tasks.html` it's called with `col_span=4` (a literal). Verify the drag placeholder spans the correct number of columns on both pages.
- [ ] **Add Task panel toggle**: The add-task form is now hidden by default and shown via a toolbar button. Confirm the toggle works on contest tasks, training program tasks, and student tasks pages. The button should only appear when the user has permission and there are unassigned tasks.
- [ ] **Visual check of alerts**: Verify info/warning alerts render correctly on the task page (validator running, not-validated), contest tasks page (contest visible warning), and anywhere the `info_alert.html` macro is used.
- [ ] **Decimal time limit input**: Test entering a decimal value (e.g. `1.5`) in the time limit field on the dataset config form, the Create Dataset modal, and the Clone Dataset modal. Verify the value saves and displays correctly.
- [ ] **Docker build on both base images**: Run `docker build --build-arg BASE_IMAGE=ubuntu:noble .` and `docker build --build-arg BASE_IMAGE=debian:bookworm .` to verify the UID 1100 fix works on both distros.

**Recommended test plan**: Build the Docker image on both base images. Open the admin interface, navigate to a contest tasks page and a training program tasks page, test the add-task toggle, search/reorder/sort. Check alert styling on the task admin page. Test decimal time limits in dataset forms.

### Notes
- The `memory_limit` field intentionally does **not** get `step='any'` since memory is specified in integer MiB.
- `student_tasks.html` has its own inline toolbar (not using the shared fragment) because it targets a different table ID (`student-tasks-table`) and doesn't need drag-drop reorder.
- The one failed ubuntu:noble CI run (job 71291524592) was a transient Docker Hub network timeout pulling postgres:15, not a code issue. The other ubuntu:noble run passed successfully.

Link to Devin session: https://app.devin.ai/sessions/efcaa147b9644e84bb38cd242ee06ffa
Requested by: @ronryv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared task toolbar with search and an optional Add Task toggle for task lists

* **Improvements**
  * Time limit inputs accept non-integer values for finer configuration
  * Alert/validation messages restyled for improved alignment and readability
  * Task reordering and table-sorting behavior consolidated into shared scripts for more consistent UX
  * Add-task panels now render only when permitted and applicable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->